### PR TITLE
Notify when offline assets are cached

### DIFF
--- a/app.js
+++ b/app.js
@@ -47,6 +47,17 @@ if ('serviceWorker' in navigator) {
         console.warn('registration.update() failed:', err);
       }
       
+      navigator.serviceWorker.addEventListener('message', (event) => {
+        if (event.data && event.data.type === 'OFFLINE_READY') {
+          showOfflineReadyNotification(event.data.cacheName);
+        }
+      });
+
+      const readyRegistration = await navigator.serviceWorker.ready;
+      if (readyRegistration.active) {
+        readyRegistration.active.postMessage({ type: 'CHECK_OFFLINE_READY' });
+      }
+
       // Optional: listen for controllerchange to detect when a new worker takes control
       navigator.serviceWorker.addEventListener('controllerchange', () => {
         console.log('controllerchange detected — a new service worker has taken control.');
@@ -90,4 +101,35 @@ function showUpdateNotification() {
   } else {
     console.warn('update-button not found when wiring click handler.');
   }
+}
+
+function showOfflineReadyNotification(cacheName = 'default') {
+  const storageKey = `offline-ready-notified-${cacheName}`;
+  if (localStorage.getItem(storageKey) === 'true') return;
+
+  localStorage.setItem(storageKey, 'true');
+  console.log('showOfflineReadyNotification called');
+
+  const notification = document.createElement('div');
+  notification.innerHTML = `
+    <div id="offline-ready-notification" style="position: fixed; top: -150px; left: 50%; z-index: 1000; transform: translateX(-50%); transition: top 0.5s ease-in-out; background: rgba(0, 0, 0, 0.9); color: #fff; border: 1px solid #2f8f2f; border-radius: 12px; padding: 12px 18px; text-align: center; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);">
+      <p style="margin: 0; font-weight: 700;">Ready for offline play!</p>
+      <p style="margin: 6px 0 0; font-size: 0.9em;">Game assets have been saved on this device.</p>
+    </div>
+  `;
+  document.body.appendChild(notification);
+
+  setTimeout(() => {
+    const el = document.getElementById('offline-ready-notification');
+    if (el) el.style.top = '20px';
+  }, 100);
+
+  setTimeout(() => {
+    const el = document.getElementById('offline-ready-notification');
+    if (el) el.style.top = '-150px';
+  }, 5000);
+
+  setTimeout(() => {
+    notification.remove();
+  }, 5600);
 }

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const APP_CACHE = 'nsk-warrior-cache-v016';
+const APP_CACHE = 'nsk-warrior-cache-v017';
 const networkFirstFiles = [
     '/',
     '/index.html',
@@ -17,9 +17,19 @@ const networkFirstFiles = [
 // Pre-cache list
 const urlsToCache = [
     '/',
+    '/index.html',
+    '/app.js',
+    '/manifest.json',
+    '/version-manager.js',
+    '/gamepad.js',
+    '/loading-ring.js',
     '/images/bearing.gif',
     '/api/serve-game/scph5501.bin?key=bios',
     '/images/NSK_Warrior_title.mp4',
+    '/images/title.avif',
+    '/images/save-placeholder.png',
+    '/favicon.ico',
+    '/db-health-checker.js',
     '/booklet/booklet.css',
     '/booklet/booklet.js',
     '/booklet/jquery-3.7.1.min.js',
@@ -51,6 +61,35 @@ const urlsToCache = [
     '/booklet/pages/20.webp'
 ];
 
+const offlineReadyFiles = [
+    ...urlsToCache,
+    '/api/serve-game/RPG_Maker_USA.zip?key=rom'
+];
+
+async function areOfflineReadyFilesCached() {
+    const cache = await caches.open(APP_CACHE);
+    const matches = await Promise.all(
+        offlineReadyFiles.map(url => cache.match(url, { ignoreVary: true }))
+    );
+    return matches.every(Boolean);
+}
+
+async function notifyClientsWhenOfflineReady() {
+    if (!(await areOfflineReadyFilesCached())) return;
+
+    const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true
+    });
+
+    clients.forEach(client => {
+        client.postMessage({
+            type: 'OFFLINE_READY',
+            cacheName: APP_CACHE
+        });
+    });
+}
+
 self.addEventListener('install', event => {
     self.skipWaiting();
     event.waitUntil(
@@ -80,8 +119,14 @@ self.addEventListener('activate', event => {
             );
         }).then(() => {
             return self.clients.claim();
-        })
+        }).then(() => notifyClientsWhenOfflineReady())
     );
+});
+
+self.addEventListener('message', event => {
+    if (event.data && event.data.type === 'CHECK_OFFLINE_READY') {
+        notifyClientsWhenOfflineReady();
+    }
 });
 
 self.addEventListener('fetch', event => {
@@ -149,6 +194,7 @@ self.addEventListener('fetch', event => {
                         try {
                             await cache.put(event.request, responseForCache);
                             console.log(`[SW] Caching complete: ${decodedPath}`);
+                            await notifyClientsWhenOfflineReady();
                         } catch (err) {
                             console.warn(`[SW] Cache failed:`, err);
                         }
@@ -176,7 +222,7 @@ self.addEventListener('fetch', event => {
             .then(networkResponse => {
                 if (networkResponse && networkResponse.ok && event.request.method === 'GET') {
                     const responseClone = networkResponse.clone();
-                    caches.open(APP_CACHE).then(cache => cache.put(event.request, responseClone));
+                    caches.open(APP_CACHE).then(cache => cache.put(event.request, responseClone)).then(() => notifyClientsWhenOfflineReady());
                 }
                 return networkResponse;
             })
@@ -193,7 +239,7 @@ self.addEventListener('fetch', event => {
                 return response || fetch(event.request).then(networkResponse => {
                     if (networkResponse && networkResponse.status === 200 && event.request.method === 'GET') {
                         const responseToCache = networkResponse.clone();
-                        caches.open(APP_CACHE).then(cache => cache.put(event.request, responseToCache));
+                        caches.open(APP_CACHE).then(cache => cache.put(event.request, responseToCache)).then(() => notifyClientsWhenOfflineReady());
                     }
                     return networkResponse;
                 });


### PR DESCRIPTION
### Motivation
- Provide a clear in-app signal when the app has finished caching the full set of assets required for offline play, including the ROM download.
- Let the page actively ask the service worker whether offline readiness has been reached and receive a single notification when it is.
- Reuse existing SW lifecycle points (install/activate/runtime caching) to detect completion without blocking gameplay streams.

### Description
- Bumped the cache name (`APP_CACHE`) and added an `offlineReadyFiles` list (pre-cache files + ROM) in `service-worker.js` to represent the assets required for offline play. 
- Implemented `areOfflineReadyFilesCached()` and `notifyClientsWhenOfflineReady()` in the service worker and call `notifyClientsWhenOfflineReady()` after activation and after runtime cache writes (ROM and network-first/cache-first flows). 
- Added a message handler in `service-worker.js` to respond to a `CHECK_OFFLINE_READY` message from clients and to post an `OFFLINE_READY` message to window clients when readiness is confirmed. 
- Wired `app.js` to post `CHECK_OFFLINE_READY` to the active worker, listen for `OFFLINE_READY`, and show a one-time-per-cache notification (`Ready for offline play!`) to the user.

### Testing
- Ran `node --check app.js` which completed successfully. 
- Ran `node --check service-worker.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0127aaf0c0832ca199c880f012465e)