### PR TITLE
Limit PWA install prompts to embedded contexts and persist user install/dismiss choices

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,13 +119,23 @@ if ('serviceWorker' in navigator) {
         readyRegistration.active.postMessage({ type: 'CHECK_OFFLINE_READY' });
       }
 
+      const isEmbedded = () => {
+        try {
+          return window.self !== window.top;
+        } catch (error) {
+          return true;
+        }
+      };
+
       window.addEventListener('beforeinstallprompt', (event) => {
+        if (!isEmbedded()) return;
+
         event.preventDefault();
         window.deferredPrompt = event;
-        notificationManager.show('INSTALL_PWA');
+        notificationManager.show('INSTALL_PWA', { source: 'iframe' });
       });
 
-      if (window.self !== window.top) {
+      if (isEmbedded()) {
         const dismissed = notificationManager.safeGetItem('install-prompt-dismissed');
         const now = Date.now();
         const oneWeek = 7 * 24 * 60 * 60 * 1000;

--- a/notification-manager.js
+++ b/notification-manager.js
@@ -170,12 +170,13 @@ class NotificationManager {
   }
 
   showInstallPwaNotification(options = {}) {
+    const accepted = this.safeGetItem('install-prompt-accepted');
     const dismissed = this.safeGetItem('install-prompt-dismissed');
     const now = Date.now();
     const oneWeek = 7 * 24 * 60 * 60 * 1000;
     const dismissedAt = dismissed ? parseInt(dismissed, 10) : 0;
 
-    if (dismissedAt && now - dismissedAt <= oneWeek) {
+    if (accepted === 'true' || (dismissedAt && now - dismissedAt <= oneWeek)) {
       return Promise.resolve();
     }
 
@@ -193,13 +194,16 @@ class NotificationManager {
     document.body.appendChild(notification);
 
     let dismissedNotification = false;
-    const dismiss = () => {
+    const closeNotification = () => {
       if (dismissedNotification) return;
       dismissedNotification = true;
-      this.safeSetItem('install-prompt-dismissed', Date.now().toString());
       const el = document.getElementById('install-pwa-notification');
       if (el) el.style.top = '-150px';
       setTimeout(() => notification.remove(), 600);
+    };
+    const rememberDismissal = () => {
+      this.safeSetItem('install-prompt-dismissed', Date.now().toString());
+      closeNotification();
     };
 
     setTimeout(() => {
@@ -207,22 +211,30 @@ class NotificationManager {
       if (el) el.style.top = '20px';
     }, 100);
 
-    document.getElementById('dismiss-pwa-button')?.addEventListener('click', dismiss);
+    document.getElementById('dismiss-pwa-button')?.addEventListener('click', rememberDismissal);
     document.getElementById('install-pwa-button')?.addEventListener('click', async () => {
       if (window.deferredPrompt) {
         window.deferredPrompt.prompt();
-        await window.deferredPrompt.userChoice;
+        const choice = await window.deferredPrompt.userChoice;
+
+        if (choice?.outcome === 'accepted') {
+          this.safeSetItem('install-prompt-accepted', 'true');
+        } else if (choice?.outcome === 'dismissed') {
+          this.safeSetItem('install-prompt-dismissed', Date.now().toString());
+        }
+
         window.deferredPrompt = null;
       } else if (options.source === 'iframe') {
         window.open(window.location.href, '_blank', 'noopener');
+        this.safeSetItem('install-prompt-dismissed', Date.now().toString());
       }
 
-      dismiss();
+      closeNotification();
     });
 
     return new Promise(resolve => {
       setTimeout(() => {
-        dismiss();
+        closeNotification();
         resolve();
       }, 8000);
     });


### PR DESCRIPTION
### Motivation
- Prevent redundant or intrusive PWA install prompts by only triggering the install flow for embedded/iframe contexts and by remembering user responses to avoid repeated prompts.
- Ensure the app respects prior user choices for install acceptance and dismissal to improve UX and reduce annoyance.

### Description
- Add `isEmbedded` helper in `app.js` and use it to only handle `beforeinstallprompt` and show the install notification when the page is embedded (`iframe`).
- Pass `source: 'iframe'` to `notificationManager.show('INSTALL_PWA')` so the notification can behave differently for embedded contexts.
- In `notification-manager.js`, add persistence of install acceptance via `install-prompt-accepted` and stop showing the prompt if accepted or recently dismissed.
- Rename and split the dismissal flow into `closeNotification` and `rememberDismissal`, persist dismissal timestamps, and record the `accepted` state when the user accepts the install prompt; also mark dismissal when opening the app in a new tab from an iframe.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0724d947f8832c8af22546a9d3a27a)