### PR TITLE
Handle direct PWA install prompt events

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,11 +128,11 @@ if ('serviceWorker' in navigator) {
       };
 
       window.addEventListener('beforeinstallprompt', (event) => {
-        if (!isEmbedded()) return;
+        const embedded = isEmbedded();
 
         event.preventDefault();
         window.deferredPrompt = event;
-        notificationManager.show('INSTALL_PWA', { source: 'iframe' });
+        notificationManager.show('INSTALL_PWA', { source: embedded ? 'iframe' : 'direct' });
       });
 
       if (isEmbedded()) {


### PR DESCRIPTION
### Motivation
- Ensure direct visits also defer the `beforeinstallprompt` event so the app can show an install UX later while preserving the existing embedded/iframe fallback behavior.

### Description
- Update the `beforeinstallprompt` handler to compute `const embedded = isEmbedded();`, always call `event.preventDefault()`, store `window.deferredPrompt = event`, and call `notificationManager.show('INSTALL_PWA', { source: embedded ? 'iframe' : 'direct' });` while leaving the iframe-only timed fallback block unchanged.

### Testing
- Ran `node --check app.js` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d21dc1b8832c9cc044c0b9c6f90e)