### PR TITLE
Restrict PWA install notification to embedded contexts

### DIFF
--- a/app.js
+++ b/app.js
@@ -132,7 +132,9 @@ if ('serviceWorker' in navigator) {
 
         event.preventDefault();
         window.deferredPrompt = event;
-        notificationManager.show('INSTALL_PWA', { source: embedded ? 'iframe' : 'direct' });
+        if (embedded) {
+          notificationManager.show('INSTALL_PWA', { source: 'iframe' });
+        }
       });
 
       if (isEmbedded()) {


### PR DESCRIPTION
### Motivation
- Avoid showing the custom `INSTALL_PWA` notification for direct (non-iframe) contexts while still suppressing the browser mini-infobar and preserving the deferred prompt behavior.

### Description
- In `app.js`'s `beforeinstallprompt` listener keep `event.preventDefault()` and `window.deferredPrompt = event`, and call `notificationManager.show('INSTALL_PWA', { source: 'iframe' })` only when `isEmbedded()` returns true, removing the previous `source: 'direct'` path from this listener and leaving the separate iframe-only delayed prompt block unchanged.

### Testing
- Performed static inspections with `rg -n "beforeinstallprompt|INSTALL_PWA|isEmbedded\(" app.js`, reviewed the `app.js` diff and file region with `nl`, and confirmed the new conditional was applied; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dde136a40832ca2d75f01da29451c)