### PR TITLE
Add PWA install info button with auto-dismiss control and expose `showModal`

### DIFF
--- a/notification-manager.js
+++ b/notification-manager.js
@@ -189,29 +189,80 @@ class NotificationManager {
           <button id="dismiss-pwa-button" class="modal-btn">Not now</button>
           <button id="install-pwa-button" class="modal-btn confirm">OK</button>
         </div>
+        <div>
+          <button id="install-pwa-info-button" class="modal-btn">What's This?</button>
+        </div>
       </div>
     `;
     document.body.appendChild(notification);
 
     let dismissedNotification = false;
+    let autoDismissTimeout = null;
+    let autoDismissStartedAt = 0;
+    let autoDismissRemaining = 8000;
+    let resolveNotification = () => {};
+
+    const clearAutoDismiss = () => {
+      if (!autoDismissTimeout) return;
+
+      clearTimeout(autoDismissTimeout);
+      autoDismissTimeout = null;
+    };
     const closeNotification = () => {
       if (dismissedNotification) return;
       dismissedNotification = true;
+      clearAutoDismiss();
       const el = document.getElementById('install-pwa-notification');
       if (el) el.classList.remove('is-visible');
       setTimeout(() => notification.remove(), 600);
+      resolveNotification();
+    };
+    const pauseAutoDismiss = () => {
+      if (!autoDismissTimeout) return;
+
+      autoDismissRemaining = Math.max(0, autoDismissRemaining - (Date.now() - autoDismissStartedAt));
+      clearAutoDismiss();
+    };
+    const startAutoDismiss = (delay = autoDismissRemaining) => {
+      if (dismissedNotification) return;
+
+      clearAutoDismiss();
+      autoDismissRemaining = delay;
+      autoDismissStartedAt = Date.now();
+      autoDismissTimeout = setTimeout(closeNotification, autoDismissRemaining);
     };
     const rememberDismissal = () => {
       this.safeSetItem('install-prompt-dismissed', Date.now().toString());
       closeNotification();
+    };
+    const showInfoModal = async () => {
+      if (dismissedNotification) return;
+
+      pauseAutoDismiss();
+
+      if (typeof window.showModal === 'function') {
+        await window.showModal([
+          'A PWA is a website that can be installed like an app for quicker launching and offline/app-like behavior.',
+          '',
+          'Chrome: use the browser install prompt if shown, or the install icon / browser menu option.',
+          'Safari: use Share, then “Add to Home Screen.”',
+          'Firefox: use the browser menu or home-screen/install option where supported.'
+        ].join('\n'), 'info');
+      } else {
+        console.warn('showModal is not available for the install PWA info dialog.');
+      }
+
+      startAutoDismiss(autoDismissRemaining);
     };
 
     setTimeout(() => {
       const el = document.getElementById('install-pwa-notification');
       if (el) el.classList.add('is-visible');
     }, 100);
+    startAutoDismiss();
 
     document.getElementById('dismiss-pwa-button')?.addEventListener('click', rememberDismissal);
+    document.getElementById('install-pwa-info-button')?.addEventListener('click', showInfoModal);
     document.getElementById('install-pwa-button')?.addEventListener('click', async () => {
       if (window.deferredPrompt) {
         window.deferredPrompt.prompt();
@@ -233,10 +284,7 @@ class NotificationManager {
     });
 
     return new Promise(resolve => {
-      setTimeout(() => {
-        closeNotification();
-        resolve();
-      }, 8000);
+      resolveNotification = resolve;
     });
   }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -74,7 +74,7 @@ html {
 .hidden { display: none !important; }
 
 .display-none { display: none; }
-.modal-copy { margin-top: 0; font-size: 1.1em; }
+.modal-copy { margin-top: 0; font-size: 1.1em; white-space: pre-line; }
 
 
 /* Notification toasts */

--- a/version-manager.js
+++ b/version-manager.js
@@ -664,6 +664,10 @@ function showModal(message, type = 'alert') {
   });
 }
 
+if (typeof window !== 'undefined') {
+  window.showModal = showModal;
+}
+
 /**
  * Handles the visual state of the booklet.
  * Returns TRUE if an action was performed (useful for stopping event chains).


### PR DESCRIPTION
### Motivation
- Provide a way for users to see an explanatory dialog about PWAs from the install prompt without the prompt auto-dismissing while the dialog is open.
- Make the existing modal helper available globally so other UI code (notifications) can invoke it.
- Ensure modal copy preserves line breaks for multi-line informational text.

### Description
- Add a "What's This?" button to the PWA install notification and a `showInfoModal` handler that pauses the notification auto-dismiss, calls `window.showModal`, and resumes auto-dismiss after the dialog closes.
- Implement auto-dismiss management helpers (`startAutoDismiss`, `pauseAutoDismiss`, `clearAutoDismiss`) and track remaining time so the install notification respects user interaction.
- Replace the fixed `setTimeout` resolution of the install-pwa promise with a stored `resolveNotification` that is invoked when the notification is closed.
- Export the modal helper by assigning `showModal` to `window.showModal` in `version-manager.js`.
- Add `white-space: pre-line` to `.modal-copy` in `styles/main.css` so multi-line modal text renders correctly.

### Testing
- Ran the project automated test suite with `npm test`, and the tests completed successfully.
- Ran the linting task with `npm run lint`, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ff8baa74832ca7b1818931d06596)