### PR TITLE
Make modals vertically scrollable

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -45,9 +45,9 @@ html {
 .ejs_small_screen #ejs-custom-exit.ejs_menu_button svg { opacity: .7; }
 #ejs-custom-exit span.ejs_menu_text_right { position: absolute; height: 14px; width: 25px; font-size: 14px; }
 
-#custom-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.6); backdrop-filter: blur(5px); z-index: 9999; display: flex; align-items: center; justify-content: center; opacity: 0; pointer-events: none; transition: opacity .3s ease; }
+#custom-modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,.6); backdrop-filter: blur(5px); z-index: 9999; display: flex; align-items: flex-start; justify-content: center; overflow-y: auto; padding: calc(env(safe-area-inset-top, 0px) + 16px) 16px calc(env(safe-area-inset-bottom, 0px) + 16px); opacity: 0; pointer-events: none; transition: opacity .3s ease; -webkit-overflow-scrolling: touch; }
 #custom-modal-overlay.visible { opacity: 1; pointer-events: auto; }
-#custom-modal { background: rgba(50,0,0,.9); border: 1px solid #a00000; border-radius: 20px; padding: 20px; width: 300px; text-align: center; box-shadow: 0 10px 30px rgba(0,0,0,.8); transform: scale(.9); transition: transform .3s cubic-bezier(.175,.885,.32,1.275); }
+#custom-modal { background: rgba(50,0,0,.9); border: 1px solid #a00000; border-radius: 20px; padding: 20px; width: min(300px, 100%); max-height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 32px); margin: auto 0; overflow-y: auto; text-align: center; box-shadow: 0 10px 30px rgba(0,0,0,.8); transform: scale(.9); transition: transform .3s cubic-bezier(.175,.885,.32,1.275); -webkit-overflow-scrolling: touch; }
 #custom-modal-overlay.visible #custom-modal { transform: scale(1); }
 .modal-btn, #update-button { background: #444; color: white; border: none; outline: none; -webkit-tap-highlight-color: transparent; padding: 10px 20px; border-radius: 20px; font-size: 1em; font-weight: bold; cursor: pointer; margin: 10px 5px 0; }
 .modal-btn.confirm { background: #a00000; }


### PR DESCRIPTION
### Motivation
- Modals were fixed to the center with no vertical scrolling which caused top/bottom content to be clipped on landscape and small viewports, so they need to be scrollable and safe‑area aware.

### Description
- Modify `styles/main.css` to make `#custom-modal-overlay` top-aligned and scrollable (`align-items: flex-start`, `overflow-y: auto`, safe-area `padding`, `-webkit-overflow-scrolling: touch`) and constrain the panel with `#custom-modal` changes (`width: min(300px, 100%)`, `max-height: calc(100dvh - env(...))` with fallbacks, `margin: auto 0`, `overflow-y: auto`) so large modal content can be reached on narrow/landscape screens.

### Testing
- Ran `git diff --check` which passed, and ran a Node check that confirmed `styles/main.css` now contains `overflow-y: auto`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c46bd3938832cb92b1b8834e83fe7)