### PR TITLE
Add native build support: Capacitor config, CI workflows, native shell and docs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,75 @@
+name: Build Android app
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'app.js'
+      - 'booklet/**'
+      - 'capacitor.config.json'
+      - 'db-health-checker.js'
+      - 'gamepad.js'
+      - 'images/**'
+      - 'index.html'
+      - 'loading-ring.js'
+      - 'manifest.json'
+      - 'native-web/**'
+      - 'notification-manager.js'
+      - 'package.json'
+      - 'scripts/**'
+      - 'service-worker.js'
+      - 'styles/**'
+      - '.github/workflows/android.yml'
+  pull_request:
+    paths:
+      - 'capacitor.config.json'
+      - 'native-web/**'
+      - 'package.json'
+      - 'scripts/**'
+      - '.github/workflows/android.yml'
+
+jobs:
+  android-debug:
+    name: Android debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prepare hosted native shell
+        run: npm run build:web
+
+      - name: Generate Android project
+        run: npx cap add android
+
+      - name: Sync Capacitor Android project
+        run: npx cap sync android
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Build debug APK
+        run: |
+          cd android
+          chmod +x ./gradlew
+          ./gradlew assembleDebug
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: nsk-warrior-android-debug-apk
+          path: android/app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,75 @@
+name: Build iOS app
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'app.js'
+      - 'booklet/**'
+      - 'capacitor.config.json'
+      - 'db-health-checker.js'
+      - 'gamepad.js'
+      - 'images/**'
+      - 'index.html'
+      - 'loading-ring.js'
+      - 'manifest.json'
+      - 'native-web/**'
+      - 'notification-manager.js'
+      - 'package.json'
+      - 'scripts/**'
+      - 'service-worker.js'
+      - 'styles/**'
+      - '.github/workflows/ios.yml'
+  pull_request:
+    paths:
+      - 'capacitor.config.json'
+      - 'native-web/**'
+      - 'package.json'
+      - 'scripts/**'
+      - '.github/workflows/ios.yml'
+
+jobs:
+  ios-simulator:
+    name: iOS simulator build
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prepare hosted native shell
+        run: npm run build:web
+
+      - name: Generate iOS project
+        run: npx cap add ios
+
+      - name: Sync Capacitor iOS project
+        run: npx cap sync ios
+
+      - name: Build unsigned iOS simulator app
+        run: |
+          xcodebuild \
+            -workspace ios/App/App.xcworkspace \
+            -scheme App \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/ios-derived \
+            build \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload simulator app
+        uses: actions/upload-artifact@v4
+        with:
+          name: nsk-warrior-ios-simulator-app
+          path: build/ios-derived/Build/Products/Debug-iphonesimulator/App.app
+          if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,43 @@
+name: Prepare Windows PWA package
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+      - 'manifest.json'
+      - 'package.json'
+      - 'scripts/**'
+      - 'native/pwabuilder-windows.json'
+      - '.github/workflows/windows.yml'
+  pull_request:
+    paths:
+      - 'manifest.json'
+      - 'native/pwabuilder-windows.json'
+      - 'scripts/**'
+      - '.github/workflows/windows.yml'
+
+jobs:
+  windows-package-request:
+    name: Windows PWABuilder package request
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate native packaging inputs
+        run: node scripts/prepare-native-web.mjs
+
+      - name: Upload PWABuilder request metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: nsk-warrior-windows-pwabuilder-request
+          path: native/pwabuilder-windows.json
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+node_modules/
+npm-debug.log*
+.DS_Store
+
+# Native build outputs
+android/.gradle/
+android/app/build/
+android/build/
+ios/App/build/
+ios/DerivedData/
+build/
+dist/
+
+# Signing material should be provided through CI secrets or local developer machines.
+*.keystore
+*.jks
+*.p12
+*.mobileprovision

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Using [**EmulatorJS**](https://github.com/EmulatorJS/) to preserve an original g
 ## Table of Contents
 - [Introduction](#introduction)
 - [Usage](#usage)
+- [Native Builds](#native-builds)
 - [Features](#features)
 - [Booklet](#booklet)
 - [License](#license)
@@ -33,6 +34,11 @@ Thanks to [**EmulatorJS**](https://github.com/EmulatorJS/), this project brings 
 To play the game, simply open your web browser and navigate to [nsk-warrior.netlify.app](https://nsk-warrior.netlify.app). Install the PWA to your home screen for a more integrated experience.
 
 The game is also available at [itch.io](https://imaginary-monkey.itch.io/nsk-warrior).
+
+
+## Native Builds
+
+This repo can also produce native app artifacts from the same main branch without changing the Netlify PWA deployment. Android and iOS use Capacitor in hosted mode so the native shells load the deployed Netlify app and keep using the existing `/api/serve-game/*` asset delivery route. Windows packaging metadata is tracked for PWABuilder/MSIX packaging. See [Native app builds](docs/native-builds.md) for local commands, CI workflows, and release signing notes.
 
 ## Features
 - **Playable in Browser:**  Enjoy the game directly in your web browser.

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,0 +1,9 @@
+{
+  "appId": "app.nskwarrior.game",
+  "appName": "NSK Warrior",
+  "webDir": "native-web",
+  "server": {
+    "url": "https://nsk-warrior.netlify.app",
+    "cleartext": false
+  }
+}

--- a/docs/native-builds.md
+++ b/docs/native-builds.md
@@ -1,0 +1,94 @@
+# Native app builds
+
+This repository keeps the Netlify PWA as the source of truth and adds native packaging as an additive layer. The native mobile shells load the deployed PWA at `https://nsk-warrior.netlify.app`, so Netlify static hosting, the service worker, and the `/api/serve-game/*` Netlify Edge Function continue to deliver game assets the same way they do for the web app.
+
+## Why hosted mode?
+
+The game ROM and BIOS assets are intentionally not committed to this repository. They are served by Netlify Blobs through `netlify/edge-functions/serve-game.js`. Loading the hosted PWA from the native shells means Android and iOS builds can use the existing asset route without duplicating private assets into native projects or changing the deployed web app.
+
+The Capacitor fallback page in `native-web/index.html` exists only so Capacitor has a valid `webDir`. At runtime, `capacitor.config.json` points the native WebView to the hosted Netlify app with `server.url`.
+
+## Repository layout
+
+- `capacitor.config.json` defines the Android/iOS app id, display name, fallback web directory, and hosted Netlify URL.
+- `native-web/index.html` is a minimal fallback page for Capacitor tooling.
+- `native/pwabuilder-windows.json` stores the Windows PWABuilder package request metadata.
+- `.github/workflows/android.yml` builds an unsigned Android debug APK artifact.
+- `.github/workflows/ios.yml` builds an unsigned iOS simulator artifact.
+- `.github/workflows/windows.yml` validates packaging inputs and uploads the PWABuilder request metadata for Windows/MSIX packaging.
+
+## Local setup
+
+Install dependencies:
+
+```sh
+npm install
+```
+
+Validate the native shell inputs:
+
+```sh
+npm run build:web
+```
+
+Generate local native projects when you want to open them in Android Studio or Xcode:
+
+```sh
+npm run android:add
+npm run ios:add
+```
+
+Sync generated projects after changing `capacitor.config.json` or web metadata:
+
+```sh
+npm run android:sync
+npm run ios:sync
+```
+
+Build locally:
+
+```sh
+npm run android:build
+npm run ios:build
+```
+
+## GitHub Actions
+
+### Android
+
+The Android workflow runs on pushes to `main`, pull requests that touch native build files, and manual `workflow_dispatch` runs. It installs dependencies, generates the Capacitor Android project, syncs it, builds a debug APK, and uploads the APK artifact.
+
+For Play Store releases, add signing secrets and a release/bundle job later. Recommended secrets are:
+
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
+### iOS
+
+The iOS workflow runs on `macos-latest`, generates the Capacitor iOS project, syncs it, builds an unsigned simulator app, and uploads the simulator artifact.
+
+For TestFlight/App Store releases, add Apple signing and export steps later. Recommended secrets are:
+
+- `APP_STORE_CONNECT_API_KEY_ID`
+- `APP_STORE_CONNECT_API_ISSUER_ID`
+- `APP_STORE_CONNECT_API_KEY_BASE64`
+- `IOS_CERTIFICATE_BASE64`
+- `IOS_CERTIFICATE_PASSWORD`
+- `IOS_PROVISIONING_PROFILE_BASE64`
+- `APPLE_TEAM_ID`
+
+### Windows
+
+Windows Store packaging for a hosted PWA is handled through PWABuilder/Microsoft Store tooling. The workflow validates the local packaging inputs and uploads `native/pwabuilder-windows.json` as an artifact so the package request is versioned with the repo.
+
+Use the artifact values with PWABuilder to generate MSIX/MSIXBUNDLE packages. If PWABuilder exposes a stable headless packaging API for this account in the future, the Windows workflow can be extended to submit `native/pwabuilder-windows.json` automatically and upload the returned MSIX artifacts.
+
+## Do these changes affect Netlify?
+
+No. The existing static app files remain at the repository root, and `netlify.toml` still maps the `serve-game` Edge Function. The native build files are additive and do not change Netlify routing or the PWA manifest/service worker used by the deployed web app.
+
+## Do we need separate repositories?
+
+No. Keep the web app, native wrapper configuration, and CI workflows in this repository. Once merged, the main branch can continue to deploy the web PWA to Netlify while GitHub Actions produces Android, iOS, and Windows packaging artifacts from the same source revision.

--- a/native-web/index.html
+++ b/native-web/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#000000">
+  <title>NSK Warrior Native Shell</title>
+  <style>
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      text-align: center;
+    }
+
+    main {
+      max-width: 32rem;
+      padding: 2rem;
+    }
+
+    a {
+      color: #fff;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>NSK Warrior</h1>
+    <p>This native wrapper loads the hosted PWA at <a href="https://nsk-warrior.netlify.app">nsk-warrior.netlify.app</a>.</p>
+    <p>If you can see this page in a native build, check the Capacitor <code>server.url</code> configuration and network access.</p>
+  </main>
+</body>
+</html>

--- a/native/pwabuilder-windows.json
+++ b/native/pwabuilder-windows.json
@@ -1,0 +1,18 @@
+{
+  "name": "NSK Warrior",
+  "packageId": "NSKWarrior",
+  "url": "https://nsk-warrior.netlify.app",
+  "startUrl": "https://nsk-warrior.netlify.app/index.html",
+  "version": "1.0.0",
+  "allowSigning": true,
+  "generateModernPackage": true,
+  "classicPackage": {
+    "generate": true,
+    "version": "1.0.0"
+  },
+  "publisher": {
+    "displayName": "James Coburn",
+    "commonName": "James Coburn"
+  },
+  "resourceLanguage": "EN-US"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,23 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@netlify/blobs": "latest"
+    "@netlify/blobs": "latest",
+    "@capacitor/core": "latest"
+  },
+  "scripts": {
+    "build:web": "node scripts/prepare-native-web.mjs",
+    "cap:sync": "npm run build:web && npx cap sync",
+    "android:add": "npx cap add android",
+    "android:sync": "npm run build:web && npx cap sync android",
+    "android:build": "npm run android:sync && cd android && ./gradlew assembleDebug",
+    "android:bundle": "npm run android:sync && cd android && ./gradlew bundleRelease",
+    "ios:add": "npx cap add ios",
+    "ios:sync": "npm run build:web && npx cap sync ios",
+    "ios:build": "npm run ios:sync && xcodebuild -workspace ios/App/App.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "latest",
+    "@capacitor/android": "latest",
+    "@capacitor/ios": "latest"
   }
 }

--- a/scripts/prepare-native-web.mjs
+++ b/scripts/prepare-native-web.mjs
@@ -1,0 +1,28 @@
+import { access, mkdir } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const requiredFiles = [
+  'index.html',
+  'manifest.json',
+  'service-worker.js',
+  'native-web/index.html',
+  'netlify/edge-functions/serve-game.js'
+];
+
+await mkdir('native-web', { recursive: true });
+
+const missing = [];
+for (const file of requiredFiles) {
+  try {
+    await access(file, constants.R_OK);
+  } catch {
+    missing.push(file);
+  }
+}
+
+if (missing.length > 0) {
+  console.error(`Missing files required for native packaging:\n${missing.map(file => `- ${file}`).join('\n')}`);
+  process.exit(1);
+}
+
+console.log('Native web shell is ready. Capacitor will load the hosted Netlify PWA via server.url.');


### PR DESCRIPTION
### Motivation
- Add native packaging support so the repository can produce Android, iOS, and Windows artifacts while keeping the Netlify PWA as the single source of truth. 
- Use Capacitor in hosted mode so native shells load the deployed PWA and continue using existing Netlify asset delivery.
- Provide automated CI to build artifacts and to version Windows PWABuilder metadata alongside the web code.

### Description
- Added GitHub Actions workflows `android.yml`, `ios.yml`, and `windows.yml` to build an Android debug APK, an unsigned iOS simulator app, and upload Windows PWABuilder metadata as artifacts. 
- Introduced `capacitor.config.json` configured to point the native WebView to the hosted Netlify URL and added a minimal fallback `native-web/index.html` for Capacitor tooling. 
- Added `scripts/prepare-native-web.mjs` to validate required web/native files and new `native/pwabuilder-windows.json` with PWABuilder metadata. 
- Updated `package.json` to include Capacitor dependencies and convenience scripts (`build:web`, `android:add`, `android:sync`, `android:build`, `ios:add`, `ios:sync`, `ios:build`, etc.).
- Added `.gitignore` entries for native build outputs and signing materials, and added `docs/native-builds.md` plus a `Native Builds` section in `README.md` describing local and CI workflows.

### Testing
- No automated test suite was executed as part of this change; the PR adds CI workflows that will run on `push`/`pull_request` and via `workflow_dispatch` to produce artifacts. 
- The added Android workflow is configured to produce an `nsk-warrior-android-debug-apk` artifact on success. 
- The added iOS workflow is configured to produce an `nsk-warrior-ios-simulator-app` artifact on success. 
- The Windows workflow validates inputs with `node scripts/prepare-native-web.mjs` and uploads `native/pwabuilder-windows.json` as `nsk-warrior-windows-pwabuilder-request`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24909e7568832cb548989000311085)