### PR TITLE
Add native build scaffolding: Capacitor config, CI workflows, and docs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,75 @@
+name: Build Android app
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'app.js'
+      - 'booklet/**'
+      - 'capacitor.config.json'
+      - 'db-health-checker.js'
+      - 'gamepad.js'
+      - 'images/**'
+      - 'index.html'
+      - 'loading-ring.js'
+      - 'manifest.json'
+      - 'native-web/**'
+      - 'notification-manager.js'
+      - 'package.json'
+      - 'scripts/**'
+      - 'service-worker.js'
+      - 'styles/**'
+      - '.github/workflows/android.yml'
+  pull_request:
+    paths:
+      - 'capacitor.config.json'
+      - 'native-web/**'
+      - 'package.json'
+      - 'scripts/**'
+      - '.github/workflows/android.yml'
+
+jobs:
+  android-debug:
+    name: Android debug APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prepare hosted native shell
+        run: npm run build:web
+
+      - name: Generate Android project
+        run: npx cap add android
+
+      - name: Sync Capacitor Android project
+        run: npx cap sync android
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Build debug APK
+        run: |
+          cd android
+          chmod +x ./gradlew
+          ./gradlew assembleDebug
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: nsk-warrior-android-debug-apk
+          path: android/app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,75 @@
+name: Build iOS app
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'app.js'
+      - 'booklet/**'
+      - 'capacitor.config.json'
+      - 'db-health-checker.js'
+      - 'gamepad.js'
+      - 'images/**'
+      - 'index.html'
+      - 'loading-ring.js'
+      - 'manifest.json'
+      - 'native-web/**'
+      - 'notification-manager.js'
+      - 'package.json'
+      - 'scripts/**'
+      - 'service-worker.js'
+      - 'styles/**'
+      - '.github/workflows/ios.yml'
+  pull_request:
+    paths:
+      - 'capacitor.config.json'
+      - 'native-web/**'
+      - 'package.json'
+      - 'scripts/**'
+      - '.github/workflows/ios.yml'
+
+jobs:
+  ios-simulator:
+    name: iOS simulator build
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Prepare hosted native shell
+        run: npm run build:web
+
+      - name: Generate iOS project
+        run: npx cap add ios
+
+      - name: Sync Capacitor iOS project
+        run: npx cap sync ios
+
+      - name: Build unsigned iOS simulator app
+        run: |
+          xcodebuild \
+            -workspace ios/App/App.xcworkspace \
+            -scheme App \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build/ios-derived \
+            build \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Upload simulator app
+        uses: actions/upload-artifact@v4
+        with:
+          name: nsk-warrior-ios-simulator-app
+          path: build/ios-derived/Build/Products/Debug-iphonesimulator/App.app
+          if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,43 @@
+name: Prepare Windows PWA package
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+      - 'manifest.json'
+      - 'package.json'
+      - 'scripts/**'
+      - 'native/pwabuilder-windows.json'
+      - '.github/workflows/windows.yml'
+  pull_request:
+    paths:
+      - 'manifest.json'
+      - 'native/pwabuilder-windows.json'
+      - 'scripts/**'
+      - '.github/workflows/windows.yml'
+
+jobs:
+  windows-package-request:
+    name: Windows PWABuilder package request
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Validate native packaging inputs
+        run: node scripts/prepare-native-web.mjs
+
+      - name: Upload PWABuilder request metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: nsk-warrior-windows-pwabuilder-request
+          path: native/pwabuilder-windows.json
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+node_modules/
+npm-debug.log*
+.DS_Store
+
+# Native build outputs
+android/.gradle/
+android/app/build/
+android/build/
+ios/App/build/
+ios/DerivedData/
+build/
+dist/
+
+# Signing material should be provided through CI secrets or local developer machines.
+*.keystore
+*.jks
+*.p12
+*.mobileprovision

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Using [**EmulatorJS**](https://github.com/EmulatorJS/) to preserve an original g
 ## Table of Contents
 - [Introduction](#introduction)
 - [Usage](#usage)
+- [Native Builds](#native-builds)
 - [Features](#features)
 - [Booklet](#booklet)
 - [License](#license)
@@ -33,6 +34,11 @@ Thanks to [**EmulatorJS**](https://github.com/EmulatorJS/), this project brings 
 To play the game, simply open your web browser and navigate to [nsk-warrior.netlify.app](https://nsk-warrior.netlify.app). Install the PWA to your home screen for a more integrated experience.
 
 The game is also available at [itch.io](https://imaginary-monkey.itch.io/nsk-warrior).
+
+
+## Native Builds
+
+This repo can also produce native app artifacts from the same main branch without changing the Netlify PWA deployment. Android and iOS use Capacitor in hosted mode so the native shells load the deployed Netlify app and keep using the existing `/api/serve-game/*` asset delivery route. Windows packaging metadata is tracked for PWABuilder/MSIX packaging. See [Native app builds](docs/native-builds.md) for local commands and CI workflows, and [Store submission and owner checklist](docs/store-submission.md) for the remaining signing, account, metadata, QA, and approval steps.
 
 ## Features
 - **Playable in Browser:**  Enjoy the game directly in your web browser.

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,0 +1,9 @@
+{
+  "appId": "app.nskwarrior.game",
+  "appName": "NSK Warrior",
+  "webDir": "native-web",
+  "server": {
+    "url": "https://nsk-warrior.netlify.app",
+    "cleartext": false
+  }
+}

--- a/docs/native-builds.md
+++ b/docs/native-builds.md
@@ -1,0 +1,104 @@
+# Native app builds
+
+This repository keeps the Netlify PWA as the source of truth and adds native packaging as an additive layer. The native mobile shells load the deployed PWA at `https://nsk-warrior.netlify.app`, so Netlify static hosting, the service worker, and the `/api/serve-game/*` Netlify Edge Function continue to deliver game assets the same way they do for the web app.
+
+## Why hosted mode?
+
+The game ROM and BIOS assets are intentionally not committed to this repository. They are served by Netlify Blobs through `netlify/edge-functions/serve-game.js`. Loading the hosted PWA from the native shells means Android and iOS builds can use the existing asset route without duplicating private assets into native projects or changing the deployed web app.
+
+The Capacitor fallback page in `native-web/index.html` exists only so Capacitor has a valid `webDir`. At runtime, `capacitor.config.json` points the native WebView to the hosted Netlify app with `server.url`.
+
+## Repository layout
+
+- `capacitor.config.json` defines the Android/iOS app id, display name, fallback web directory, and hosted Netlify URL.
+- `native-web/index.html` is a minimal fallback page for Capacitor tooling.
+- `native/pwabuilder-windows.json` stores the Windows PWABuilder package request metadata.
+- `.github/workflows/android.yml` builds an unsigned Android debug APK artifact.
+- `.github/workflows/ios.yml` builds an unsigned iOS simulator artifact.
+- `.github/workflows/windows.yml` validates packaging inputs and uploads the PWABuilder request metadata for Windows/MSIX packaging.
+
+## Local setup
+
+Install dependencies:
+
+```sh
+npm install
+```
+
+Validate the native shell inputs:
+
+```sh
+npm run build:web
+```
+
+Generate local native projects when you want to open them in Android Studio or Xcode:
+
+```sh
+npm run android:add
+npm run ios:add
+```
+
+Sync generated projects after changing `capacitor.config.json` or web metadata:
+
+```sh
+npm run android:sync
+npm run ios:sync
+```
+
+Build locally:
+
+```sh
+npm run android:build
+npm run ios:build
+```
+
+## GitHub Actions
+
+See [Store submission and owner checklist](store-submission.md) for the owner-side signing, account, metadata, testing, and approval steps that are still required before public release.
+
+
+### Android
+
+The Android workflow runs on pushes to `main`, pull requests that touch native build files, and manual `workflow_dispatch` runs. It installs dependencies, generates the Capacitor Android project, syncs it, builds a debug APK, and uploads the APK artifact.
+
+For Play Store releases, add signing secrets and a release/bundle job later. Recommended secrets are:
+
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
+### iOS
+
+The iOS workflow runs on `macos-latest`, generates the Capacitor iOS project, syncs it, builds an unsigned simulator app, and uploads the simulator artifact.
+
+For TestFlight/App Store releases, add Apple signing and export steps later. Recommended secrets are:
+
+- `APP_STORE_CONNECT_API_KEY_ID`
+- `APP_STORE_CONNECT_API_ISSUER_ID`
+- `APP_STORE_CONNECT_API_KEY_BASE64`
+- `IOS_CERTIFICATE_BASE64`
+- `IOS_CERTIFICATE_PASSWORD`
+- `IOS_PROVISIONING_PROFILE_BASE64`
+- `APPLE_TEAM_ID`
+
+### Windows
+
+Windows Store packaging for a hosted PWA is handled through PWABuilder/Microsoft Store tooling. The workflow validates the local packaging inputs and uploads `native/pwabuilder-windows.json` as an artifact so the package request is versioned with the repo.
+
+Use the artifact values with PWABuilder to generate MSIX/MSIXBUNDLE packages. If PWABuilder exposes a stable headless packaging API for this account in the future, the Windows workflow can be extended to submit `native/pwabuilder-windows.json` automatically and upload the returned MSIX artifacts.
+
+## Do these changes affect Netlify?
+
+No. The existing static app files remain at the repository root, and `netlify.toml` still maps the `serve-game` Edge Function. The native build files are additive and do not change Netlify routing or the PWA manifest/service worker used by the deployed web app.
+
+## Do we need separate repositories?
+
+No. Keep the web app, native wrapper configuration, and CI workflows in this repository. Once merged, the main branch can continue to deploy the web PWA to Netlify while GitHub Actions produces Android, iOS, and Windows packaging artifacts from the same source revision.
+
+
+## Current limitations
+
+- The Android workflow currently produces an unsigned debug APK for testing. Google Play production release still needs a signed Android App Bundle (`.aab`) workflow after keystore secrets are available.
+- The iOS workflow currently produces an unsigned simulator build. App Store/TestFlight release still needs Apple signing assets and App Store Connect upload automation.
+- The Windows workflow currently validates and uploads PWABuilder request metadata. It does not yet generate an MSIX automatically because the maintained PWABuilder flow is service/UI-driven; full automation should be added only after choosing a stable Windows packaging tool or API.

--- a/docs/store-submission.md
+++ b/docs/store-submission.md
@@ -1,0 +1,97 @@
+# Store submission and owner checklist
+
+The native build configuration in this repo is enough to start producing test artifacts, but public store approval still requires account, signing, metadata, testing, and reviewer-submission work that cannot be fully completed from the repository alone.
+
+## What is already set up
+
+- Android and iOS native shells use Capacitor in hosted mode and point at the deployed Netlify PWA.
+- The Netlify PWA remains the single source of truth for the web experience and game asset delivery.
+- GitHub Actions can generate an Android debug APK and an unsigned iOS simulator app for smoke testing.
+- Windows PWABuilder metadata is versioned in the repo so the Windows package request can be generated consistently.
+
+## What still needs to happen
+
+### 1. Verify the hosted app before store submission
+
+Before submitting to any store, confirm that `https://nsk-warrior.netlify.app` is production-ready because Android/iOS hosted-mode wrappers load that URL at runtime.
+
+Owner tasks:
+
+- Confirm the production URL, app name, support email, website URL, privacy policy URL, and store descriptions are final.
+- Test a full game session from the production URL, including game asset download, save/import/share/delete behavior, offline behavior, booklet controls, gamepad behavior, and reload behavior.
+- Confirm all required ROM/BIOS assets exist in Netlify Blobs and that `/api/serve-game/*` works from the production host.
+- Prepare final screenshots, feature graphic/banner art, app icon, age-rating answers, support contact details, and review notes.
+
+### 2. Add release signing when you are ready to publish
+
+The current workflows are intentionally unsigned/test-oriented. Public stores require signed release artifacts.
+
+Owner tasks:
+
+- Create developer accounts for Google Play Console, Apple Developer/App Store Connect, and Microsoft Partner Center.
+- Decide who owns the app identifiers and certificates permanently. These identities are difficult or impossible to reuse after submission.
+- Add repository or organization secrets for Android, iOS, and Windows signing only after the release process is agreed.
+- Add release workflows after credentials are available. The current workflows are safe starter workflows and avoid committing certificates or private keys.
+
+### 3. Decide whether hosted mode is acceptable for Apple review
+
+Android and Windows generally align well with hosted PWA packaging. iOS can be stricter: Apple App Review Guideline 4.2 expects an app to provide lasting value and not feel like only a repackaged website. NSK Warrior is a playable game rather than a generic website, which helps, but Apple may still scrutinize a hosted WebView wrapper.
+
+Recommended owner tasks for iOS:
+
+- Add App Review notes explaining that the app is a complete playable game, not a marketing page or link collection.
+- Emphasize the game content, fullscreen play, offline/service-worker behavior, save-state functionality, booklet, and gamepad/touch controls.
+- Test on real iPhone/iPad hardware before submitting.
+- Be prepared to add small native integrations later if Apple asks for more app-specific behavior, such as native orientation handling, native share hooks, haptics, or local notification hooks.
+
+## Android approval process
+
+1. Register or use an existing Google Play Console developer account.
+2. Create the app in Play Console with the final app/game name, default language, free/paid choice, contact email, declarations, and Play App Signing acceptance.
+3. Generate a release Android App Bundle (`.aab`), not just the debug APK currently produced by CI.
+4. Sign the release upload with your upload key or configure Play App Signing.
+5. Complete Play Console dashboard tasks: store listing, screenshots, content rating, target audience, data safety/privacy disclosures, ads declaration, app category/tags, support contact, and countries/regions.
+6. Run internal or closed testing first. Personal Play Console accounts created after November 13, 2023 may have additional testing requirements before production release.
+7. Submit changes for review through the Publishing overview, optionally using managed publishing so approval and public rollout are separate steps.
+8. If rejected, fix the policy or technical issue, increment the Android version code, upload a new bundle, and resubmit.
+
+## iOS approval process
+
+1. Join or use an Apple Developer Program account.
+2. Create or confirm the bundle identifier that matches `app.nskwarrior.game`.
+3. Generate the iOS project with Capacitor, configure signing in Xcode, and create an archive for distribution.
+4. Upload a signed build through Xcode, Transporter, Xcode Cloud, or App Store Connect API tooling.
+5. Create the app record in App Store Connect with app name, SKU, bundle ID, primary language, age rating, category, screenshots, privacy details, support URL, marketing URL, and review notes.
+6. Use TestFlight for internal/external testing before production review.
+7. Select the processed build for the app version and submit it to App Review.
+8. If rejected, respond in App Store Connect with clarification or submit a corrected build. For WebView/minimum-functionality concerns, update review notes and/or add native functionality if needed.
+
+## Windows approval process
+
+1. Register or use a Microsoft Partner Center developer account.
+2. Use PWABuilder with the production URL and the metadata in `native/pwabuilder-windows.json` to generate the Windows/MSIX package.
+3. Test the package locally and run the Windows App Certification Kit before submission.
+4. Create a Microsoft Store app submission with package, Store listing, screenshots, age rating, pricing/availability, support details, privacy policy, and certification notes.
+5. Submit to certification. Microsoft states certification can take up to three business days, and approved listings normally appear shortly after publishing completes.
+6. If certification fails, use the certification report to fix the package, policy, or listing issue, then create a new submission.
+
+## Recommended next implementation steps
+
+These are not required for the Netlify web app to keep working, but they are recommended before public store launch:
+
+1. Add a release Android workflow that produces a signed `.aab` once Android keystore secrets are available.
+2. Add an iOS release workflow after Apple signing assets and App Store Connect API credentials are available.
+3. Decide whether Windows should remain PWABuilder/manual or move to a fully generated Windows wrapper using a tool such as Electron, Tauri, or Microsoft's Windows App SDK/MSIX tooling.
+4. Add platform-specific release notes and review-note templates under `docs/` so each submission explains the hosted PWA/game architecture consistently.
+5. Run at least one end-to-end manual QA pass on Android hardware, iPhone/iPad hardware, and Windows before submitting to stores.
+
+
+## Official references
+
+- Google Play Console: Create and set up your app — https://support.google.com/googleplay/android-developer/answer/9859152
+- Google Play Console: Use Play App Signing — https://support.google.com/googleplay/android-developer/answer/9842756
+- Apple Developer: App Store Review Guidelines — https://developer.apple.com/app-store/review/guidelines/
+- Apple Developer: Upload builds — https://developer.apple.com/help/app-store-connect/manage-builds/upload-builds
+- Apple Developer: Submit an app — https://developer.apple.com/help/app-store-connect/manage-submissions-to-app-review/submit-an-app/
+- Microsoft Learn: Create an app submission for your PWA — https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/pwa/create-app-submission
+- Microsoft Learn: The app certification process for PWA — https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/pwa/app-certification-process

--- a/native-web/index.html
+++ b/native-web/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="theme-color" content="#000000">
+  <title>NSK Warrior Native Shell</title>
+  <style>
+    html,
+    body {
+      height: 100%;
+      margin: 0;
+      background: #000;
+      color: #fff;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    body {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      text-align: center;
+    }
+
+    main {
+      max-width: 32rem;
+      padding: 2rem;
+    }
+
+    a {
+      color: #fff;
+      font-weight: 700;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>NSK Warrior</h1>
+    <p>This native wrapper loads the hosted PWA at <a href="https://nsk-warrior.netlify.app">nsk-warrior.netlify.app</a>.</p>
+    <p>If you can see this page in a native build, check the Capacitor <code>server.url</code> configuration and network access.</p>
+  </main>
+</body>
+</html>

--- a/native/pwabuilder-windows.json
+++ b/native/pwabuilder-windows.json
@@ -1,0 +1,18 @@
+{
+  "name": "NSK Warrior",
+  "packageId": "NSKWarrior",
+  "url": "https://nsk-warrior.netlify.app",
+  "startUrl": "https://nsk-warrior.netlify.app/index.html",
+  "version": "1.0.0",
+  "allowSigning": true,
+  "generateModernPackage": true,
+  "classicPackage": {
+    "generate": true,
+    "version": "1.0.0"
+  },
+  "publisher": {
+    "displayName": "James Coburn",
+    "commonName": "James Coburn"
+  },
+  "resourceLanguage": "EN-US"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,23 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "@netlify/blobs": "latest"
+    "@netlify/blobs": "latest",
+    "@capacitor/core": "latest"
+  },
+  "scripts": {
+    "build:web": "node scripts/prepare-native-web.mjs",
+    "cap:sync": "npm run build:web && npx cap sync",
+    "android:add": "npx cap add android",
+    "android:sync": "npm run build:web && npx cap sync android",
+    "android:build": "npm run android:sync && cd android && ./gradlew assembleDebug",
+    "android:bundle": "npm run android:sync && cd android && ./gradlew bundleRelease",
+    "ios:add": "npx cap add ios",
+    "ios:sync": "npm run build:web && npx cap sync ios",
+    "ios:build": "npm run ios:sync && xcodebuild -workspace ios/App/App.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO"
+  },
+  "devDependencies": {
+    "@capacitor/cli": "latest",
+    "@capacitor/android": "latest",
+    "@capacitor/ios": "latest"
   }
 }

--- a/scripts/prepare-native-web.mjs
+++ b/scripts/prepare-native-web.mjs
@@ -1,0 +1,28 @@
+import { access, mkdir } from 'node:fs/promises';
+import { constants } from 'node:fs';
+
+const requiredFiles = [
+  'index.html',
+  'manifest.json',
+  'service-worker.js',
+  'native-web/index.html',
+  'netlify/edge-functions/serve-game.js'
+];
+
+await mkdir('native-web', { recursive: true });
+
+const missing = [];
+for (const file of requiredFiles) {
+  try {
+    await access(file, constants.R_OK);
+  } catch {
+    missing.push(file);
+  }
+}
+
+if (missing.length > 0) {
+  console.error(`Missing files required for native packaging:\n${missing.map(file => `- ${file}`).join('\n')}`);
+  process.exit(1);
+}
+
+console.log('Native web shell is ready. Capacitor will load the hosted Netlify PWA via server.url.');


### PR DESCRIPTION
### Motivation

- Enable producing native app artifacts (Android debug APK, iOS simulator app, and Windows PWABuilder metadata) from the same repository without changing the deployed Netlify PWA. 
- Provide a minimal hosted-mode Capacitor configuration so native shells load the hosted PWA and reuse the existing asset delivery route.
- Document owner-facing store submission steps and local/CI commands to prepare release artifacts.

### Description

- Add `capacitor.config.json` configured for hosted mode pointing at `https://nsk-warrior.netlify.app` and add a minimal fallback `native-web/index.html` for Capacitor tooling. 
- Add GitHub Actions workflows: `android.yml` to build an unsigned debug APK, `ios.yml` to build an unsigned iOS simulator app, and `windows.yml` to validate and upload PWABuilder request metadata. 
- Add packaging metadata `native/pwabuilder-windows.json`, helper script `scripts/prepare-native-web.mjs`, and update `package.json` with Capacitor dependencies and convenience scripts (`build:web`, `android:add`, `ios:add`, `android:build`, `ios:build`, etc.).
- Add documentation `docs/native-builds.md` and `docs/store-submission.md`, update `README.md` with a "Native Builds" section, and add a `.gitignore` to exclude native build outputs and signing material.

### Testing

- Ran the native shell preparation script with `node scripts/prepare-native-web.mjs` (via `npm run build:web`) and it completed successfully. 
- No CI workflow runs were executed as part of this change; the new GitHub Actions will run on pushes to `main`, pull requests touching native files, or manual `workflow_dispatch` triggers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24909e7568832cb548989000311085)