### PR TITLE
Feat/android tauri workflow 10744433684619836113

### DIFF
--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   build-android:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -21,7 +23,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/tauri-android.yml
+++ b/.github/workflows/tauri-android.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build Android App
         run: |
           export NDK_HOME=$ANDROID_HOME/ndk/25.1.8937393
-          npx tauri android build --apk --debug
+          npx tauri android build --apk --debug --split-per-abi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tauri-windows.yml
+++ b/.github/workflows/tauri-windows.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build-windows:
     runs-on: windows-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,7 +21,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
*   Created a new `tauri-android.yml` workflow. It correctly provisions the `ubuntu-latest` runner with Android SDK and NDK version `25.1.8937393`, building the Tauri project via `npx tauri android build --apk --debug --split-per-abi`.
*   Committed the `src-tauri/gen/android` directory generated by `npx tauri android init`. This ensures that the generated Kotlin code and Gradle configuration are available for CI to build successfully.
*   Updated `package.json` to include a `tauri` alias, facilitating local CLI execution via `npx tauri`.
*   The `.apk` files are uploaded as downloadable workflow artifacts for manual testing on real devices. They are generated with the `--split-per-abi` flag to keep sizes small (from ~500MB universal APK down to ~130MB per architecture).
*   Upgraded `actions/setup-node` usage across `.github/workflows` to Node 24 to resolve warnings about the deprecation of Node 20 runners.