### PR TITLE
Fix window.location evaluation in node environment

### DIFF
--- a/version-manager.js
+++ b/version-manager.js
@@ -3,7 +3,7 @@
  */
 
 // --- 1. CONFIGURATION ---
-const isTauri = typeof window !== 'undefined' && (window.location.hostname === 'tauri.localhost' || window.location.protocol === 'tauri:');
+const isTauri = typeof window !== 'undefined' && window.location && (window.location.hostname === 'tauri.localhost' || window.location.protocol === 'tauri:');
 const baseUrl = isTauri ? 'https://nsk-warrior.netlify.app' : '';
 
 const APP_CONFIG = {


### PR DESCRIPTION
- Updated the guard around window.location to check if it actually exists, preventing node from erroring during build
- The start UI now successfully loads since `window.location` evaluation is correctly guarded.