### PR TITLE
Fix rendering artifact at the top of the app

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -13,6 +13,19 @@ html {
   font-family: system-ui, sans-serif;
 }
 
+/* Overlay to hide rendering artifacts at the top of the screen */
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 9px;
+  background-color: #000000;
+  z-index: 999999;
+  pointer-events: none;
+}
+
 .bg-layer { position: absolute; width: 100%; top: 50%; transform: translateY(-50%); max-width: 100vw; z-index: 0; opacity: 0.75; }
 
 #game-container { position: absolute; inset: 0; box-sizing: border-box; width: 100%; height: 100%; display: none; flex-direction: column; align-items: center; justify-content: center; z-index: 10; overflow: hidden; }


### PR DESCRIPTION
Fix rendering artifact at the top of the app

Adds a black, fixed 9px high CSS overlay (`body::before`) to mask a rendering artifact that appears as a thin gray or red line at the top edge of the app when installed as a PWA or APK.


---
*PR created automatically by Jules for task [17423790734064354635](https://jules.google.com/task/17423790734064354635) started by @not-that-james-coburn*