### PR TITLE
Fix top line rendering artifact with safe CSS height fills

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -6,24 +6,17 @@ html {
   margin: 0;
   padding: 0;
   height: 100dvh;
+  min-height: 100vh;
+  min-height: -webkit-fill-available;
   width: 100%;
-  background: #000000;
+  background-color: #000000;
   color: white;
   overflow: hidden;
   font-family: system-ui, sans-serif;
 }
 
-/* Overlay to hide rendering artifacts at the top of the screen */
-body::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 9px;
-  background-color: #000000;
-  z-index: 999999;
-  pointer-events: none;
+html {
+  height: -webkit-fill-available;
 }
 
 .bg-layer { position: absolute; width: 100%; top: 50%; transform: translateY(-50%); max-width: 100vw; z-index: 0; opacity: 0.75; }


### PR DESCRIPTION
Removes the previous DOM overlay workaround. Instead, updates global styles for `html` and `body` to explicitly set `background-color` and incorporate `min-height: -webkit-fill-available`. This ensures the app container correctly sizes across different mobile views (especially upon orientation changes) to eliminate sub-pixel gaps that reveal background color/rendering lines.