### PR TITLE
Fix viewport rendering artifact with explicit viewport scaling and ba…

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/styles/main.css
+++ b/styles/main.css
@@ -13,6 +13,8 @@ html {
   color: white;
   overflow: hidden;
   font-family: system-ui, sans-serif;
+  box-shadow: inset 0 0 0 10px #000000, 0 0 0 10px #000000;
+  outline: 10px solid #000000;
 }
 
 html {


### PR DESCRIPTION
…ckground edge mask

Updates the viewport meta tag to include `maximum-scale=1.0` and `user-scalable=no` to prevent unwanted scaling. Adds a drastic 10px black `box-shadow` and `outline` to the `html` element, forcing the background color to bleed outwards, covering any sub-pixel rendering gaps at the edges (especially on rotation) in PWAs and webviews.