### PR TITLE
refactor: convert excessive console.log to console.debug

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ if ('serviceWorker' in navigator) {
   window.addEventListener('load', async () => {
     try {
       const registration = await navigator.serviceWorker.register('/service-worker.js', { scope: '/' });
-      console.log('ServiceWorker registration successful with scope: ', registration.scope);
+      console.debug('ServiceWorker registration successful with scope: ', registration.scope);
 
       const reloadForApprovedUpdate = (reason) => {
         if (refreshingForUpdate) return;
@@ -21,7 +21,7 @@ if ('serviceWorker' in navigator) {
           updateReloadFallbackTimer = null;
         }
 
-        console.log(`${reason} — reloading for the approved service worker update.`);
+        console.debug(`${reason} — reloading for the approved service worker update.`);
         window.location.reload();
       };
 
@@ -68,16 +68,16 @@ if ('serviceWorker' in navigator) {
       // Helper to handle an installing worker's lifecycle
       const handleInstalling = (worker) => {
         if (!worker) return;
-        console.log('Service worker installing:', worker);
+        console.debug('Service worker installing:', worker);
         worker.addEventListener('statechange', () => {
-          console.log('Installing worker statechange:', worker.state);
+          console.debug('Installing worker statechange:', worker.state);
           if (worker.state === 'installed') {
             // If there's an active controller, this is an update (not first install)
             if (navigator.serviceWorker.controller) {
-              console.log('New service worker installed (update).');
+              console.debug('New service worker installed (update).');
               showUpdateAvailable(worker);
             } else {
-              console.log('Service worker installed for the first time (no prior controller).');
+              console.debug('Service worker installed for the first time (no prior controller).');
             }
           }
         });
@@ -85,7 +85,7 @@ if ('serviceWorker' in navigator) {
 
       // If there's already a waiting worker, treat that as an available update
       if (registration.waiting) {
-        console.log('Found waiting worker on register — treating as update.');
+        console.debug('Found waiting worker on register — treating as update.');
         showUpdateAvailable(registration.waiting);
       }
 
@@ -96,14 +96,14 @@ if ('serviceWorker' in navigator) {
 
       // Always attach updatefound to catch new installs — do this BEFORE update()
       registration.addEventListener('updatefound', () => {
-        console.log('updatefound fired on registration');
+        console.debug('updatefound fired on registration');
         handleInstalling(registration.installing);
       });
 
       // Check for updates before calling update() to avoid race.
       try {
         await registration.update();
-        console.log('registration.update() completed.');
+        console.debug('registration.update() completed.');
       } catch (err) {
         console.warn('registration.update() failed:', err);
       }
@@ -150,7 +150,7 @@ if ('serviceWorker' in navigator) {
         }
       }
     } catch (error) {
-      console.log('ServiceWorker registration failed: ', error);
+      console.error('ServiceWorker registration failed: ', error);
     }
   });
 }

--- a/db-health-checker.js
+++ b/db-health-checker.js
@@ -3,7 +3,7 @@
   const TARGET_DB = 'EmulatorJS-states'; 
   const REQUIRED_STORE = 'states';       
 
-  console.log("[Health Check] Checking database integrity...");
+  console.debug("[Health Check] Checking database integrity...");
 
   const req = window.indexedDB.open(TARGET_DB);
   let createdDummyDB = false;
@@ -21,7 +21,7 @@
     // It's empty, but that's normal. We need to delete it so the Emulator
     // can run its own creation logic properly.
     if (createdDummyDB) {
-      console.log("[Health Check] No existing DB found (Clean slate). Cleaning up check...");
+      console.debug("[Health Check] No existing DB found (Clean slate). Cleaning up check...");
       db.close();
       window.indexedDB.deleteDatabase(TARGET_DB); // Remove our dummy trace
       return;
@@ -36,17 +36,17 @@
       // Delete the broken DB and reload to force a fresh start
       const deleteReq = window.indexedDB.deleteDatabase(TARGET_DB);
       deleteReq.onsuccess = () => {
-        console.log("[Health Check] Corrupted DB deleted. Reloading to initialize...");
+        console.debug("[Health Check] Corrupted DB deleted. Reloading to initialize...");
         window.location.reload();
       };
     } else {
       // CASE C: DB exists and has the store. All good.
-      console.log("[Health Check] Database is healthy.");
+      console.debug("[Health Check] Database is healthy.");
       db.close();
     }
   };
 
   req.onerror = function(e) {
-    console.log("[Health Check] Could not open DB (Blocked or Private Mode).");
+    console.debug("[Health Check] Could not open DB (Blocked or Private Mode).");
   };
 })();

--- a/gamepad.js
+++ b/gamepad.js
@@ -28,7 +28,7 @@ const crossSVG = `
 
 // Define the initialization function globally
 window.initVirtualGamepad = function() {
-  console.log("Initializing Virtual Gamepad Customizations...");
+  console.debug("Initializing Virtual Gamepad Customizations...");
   
   function applyCustomStyles() {
     if (document.getElementById('custom-gamepad-styles')) return;

--- a/loading-ring.js
+++ b/loading-ring.js
@@ -109,7 +109,7 @@ const callback = function(mutationsList, observer) {
         if (taskName && taskName !== myLoader.lastTaskName) {
             myLoader.lastTaskName = taskName;
             myLoader.resetForNewTask();
-            console.log(`[Loader] New task: "${taskName}"`);
+            console.debug(`[Loader] New task: "${taskName}"`);
             
             // Update task label immediately
             statusLabel.textContent = taskName;
@@ -133,7 +133,7 @@ const callback = function(mutationsList, observer) {
                 if ((canvas && canvas.offsetParent !== null) ||
                     (emulator && emulator.gameManager && !emulator.paused)) {
                     
-                    console.log('[Loader] Game started, hiding overlay');
+                    console.debug('[Loader] Game started, hiding overlay');
                     myLoader.hideOverlay();
                     clearInterval(emulatorReadyCheckInterval);
                     emulatorReadyCheckInterval = null;
@@ -143,7 +143,7 @@ const callback = function(mutationsList, observer) {
         }
     } else {
         // Loading element disappeared - game is taking over, hide overlay
-        console.log('[Loader] Loading element disappeared, hiding overlay');
+        console.debug('[Loader] Loading element disappeared, hiding overlay');
         myLoader.hideOverlay();
         if (emulatorReadyCheckInterval) clearInterval(emulatorReadyCheckInterval);
         emulatorReadyCheckInterval = null;

--- a/netlify/edge-functions/serve-game.js
+++ b/netlify/edge-functions/serve-game.js
@@ -5,7 +5,7 @@ export default async (request, context) => {
   const fileKey = url.searchParams.get("key"); 
 
   // --- DEBUG LOGGING (Check Netlify Function Logs if errors persist) ---
-  console.log(`[ServeGame] Request for key: ${fileKey}`);
+  console.debug(`[ServeGame] Request for key: ${fileKey}`);
   
   // --- SECURITY CHECK ---
   const referer = request.headers.get("referer");

--- a/notification-manager.js
+++ b/notification-manager.js
@@ -101,7 +101,7 @@ class NotificationManager {
   }
 
   showUpdateNotification(options = {}) {
-    console.log('showUpdateNotification called');
+    console.debug('showUpdateNotification called');
     const notification = document.createElement('div');
     notification.innerHTML = `
       <div id="update-notification" class="notice-toast notice-toast--panel">
@@ -146,7 +146,7 @@ class NotificationManager {
     if (this.safeGetItem(storageKey) === 'true') return Promise.resolve();
 
     this.safeSetItem(storageKey, 'true');
-    console.log('showOfflineReadyNotification called');
+    console.debug('showOfflineReadyNotification called');
 
     const notification = document.createElement('div');
     notification.innerHTML = `

--- a/service-worker.js
+++ b/service-worker.js
@@ -155,7 +155,7 @@ self.addEventListener('fetch', event => {
                 // 1. Try Cache First
                 const cachedResponse = await cache.match(event.request, { ignoreVary: true, ignoreMethod: true });
                 if (cachedResponse) {
-                    console.log(`[SW] serving cached HEAD for: ${decodedPath}`);
+                    console.debug(`[SW] serving cached HEAD for: ${decodedPath}`);
                     return new Response(null, {
                         status: 200,
                         statusText: 'OK',
@@ -169,7 +169,7 @@ self.addEventListener('fetch', event => {
                     return networkResponse;
                 } catch (e) {
                     // Only return 404 if BOTH cache and network fail (Offline & Not Cached)
-                    console.log(`[SW] Offline and not cached: ${decodedPath}`);
+                    console.debug(`[SW] Offline and not cached: ${decodedPath}`);
                     return new Response(null, { status: 404, statusText: 'Offline' });
                 }
             }
@@ -180,7 +180,7 @@ self.addEventListener('fetch', event => {
                 const cachedResponse = await cache.match(event.request, { ignoreVary: true });
                 if (cachedResponse) return cachedResponse;
                 
-                console.log(`[SW] Downloading ROM: ${decodedPath}`);
+                console.debug(`[SW] Downloading ROM: ${decodedPath}`);
                 
                 // 2. Fetch from Network
                 try {
@@ -204,7 +204,7 @@ self.addEventListener('fetch', event => {
                     (async () => {
                         try {
                             await cache.put(event.request, responseForCache);
-                            console.log(`[SW] Caching complete: ${decodedPath}`);
+                            console.debug(`[SW] Caching complete: ${decodedPath}`);
                             await notifyClientsWhenOfflineReady();
                         } catch (err) {
                             console.warn(`[SW] Cache failed:`, err);
@@ -238,7 +238,7 @@ self.addEventListener('fetch', event => {
                 return networkResponse;
             })
             .catch(() => {
-                console.log(`[SW] Network failed for ${decodedPath}, checking cache...`);
+                console.debug(`[SW] Network failed for ${decodedPath}, checking cache...`);
                 return caches.match(event.request);
             })
         );

--- a/version-manager.js
+++ b/version-manager.js
@@ -1267,7 +1267,7 @@ function injectExitButton() {
       
       // Append to the toolbar
       toolbar.appendChild(btn);
-      console.log("Custom Exit Button injected.");
+      console.debug("Custom Exit Button injected.");
     }
     
     // Stop trying after 10 seconds
@@ -1470,7 +1470,7 @@ async function launchGame(verId, slotNum) {
   window.EJS_color = "#000000";
   window.EJS_backgroundColor = "#000000";
   window.EJS_threads = (typeof SharedArrayBuffer !== 'undefined' && typeof Atomics !== 'undefined');
-  console.log("Threads enabled?", EJS_threads);
+  console.debug("Threads enabled?", EJS_threads);
   window.EJS_Buttons = { restart: false, fullscreen: false };
   window.EJS_defaultOptions = { 'save-state-location': 'browser' };
   window.EJS_DEBUG_XX = APP_CONFIG.debug;


### PR DESCRIPTION
Converts excessive `console.log` statements to `console.debug()` across multiple files (`app.js`, `service-worker.js`, `db-health-checker.js`, `gamepad.js`, `loading-ring.js`, `notification-manager.js`, `version-manager.js`, `netlify/edge-functions/serve-game.js`). 
Keeps explicit saving and loading events in `version-manager.js` as `console.log()` as requested.

---
*PR created automatically by Jules for task [3476043396427779482](https://jules.google.com/task/3476043396427779482) started by @not-that-james-coburn*