### PR TITLE
Fix long-press haptic bump by making touchstart non-passive

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -91,8 +91,12 @@ window.initVirtualGamepad = function() {
   
   // Disable default actions
   document.addEventListener('contextmenu', (e) => e.preventDefault());
-  document.addEventListener('touchstart', (e) => e.preventDefault());
-  document.addEventListener('pointerdown', (e) => e.preventDefault());
+  document.addEventListener('touchstart', (e) => {
+    // Only prevent default if it's not a multi-touch gesture intended for zoom,
+    // although touch-action: none should handle that.
+    e.preventDefault();
+  }, { passive: false });
+  document.addEventListener('pointerdown', (e) => e.preventDefault(), { passive: false });
   
   function applyStyles() {
     const virtualGamepadLeft = document.querySelector('.ejs_virtualGamepad_left');


### PR DESCRIPTION
- Updated `document.addEventListener('touchstart')` and `pointerdown` in `gamepad.js` to explicitly use `{ passive: false }`. Modern mobile browsers treat document-level touch listeners as passive by default for scroll optimization, which causes `e.preventDefault()` to be ignored, allowing native OS haptics and magnifiers to trigger.
- Retained the `touch-action: none`, `user-select: none`, and `-webkit-touch-callout: none` CSS properties to ensure text selection and context menus are thoroughly disabled.