### PR TITLE
Exempt custom UI elements from aggressive touch event prevention

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,7 @@
 const notificationManager = window.notificationManager || new window.NotificationManager();
 window.notificationManager = notificationManager;
 
-// Disable context menu globally
-document.addEventListener('contextmenu', event => event.preventDefault());
+// Disable context menu globally (managed more specifically in gamepad.js now)
 
 let refreshingForUpdate = false;
 let updateReloadRequested = false;

--- a/gamepad.js
+++ b/gamepad.js
@@ -89,14 +89,31 @@ window.initVirtualGamepad = function() {
   }
   
   
-  // Disable default actions
-  document.addEventListener('contextmenu', (e) => e.preventDefault());
+  // Determine if a touch event should be allowed (not prevented)
+  function shouldAllowTouch(e) {
+    if (!e.target) return false;
+
+    // Allow touch on specific interactive UI overlays
+    const isBooklet = e.target.closest('#book-container');
+    const isModal = e.target.closest('#custom-modal-overlay');
+    const isUiLayer = e.target.closest('#ui-layer');
+    const isEjsMenu = e.target.closest('.ejs_menu_parent') || e.target.closest('.ejs_menu_button');
+
+    return isBooklet || isModal || isUiLayer || isEjsMenu;
+  }
+
+  // Disable default actions globally, but allow them for our custom UI
+  document.addEventListener('contextmenu', (e) => {
+    if (!shouldAllowTouch(e)) e.preventDefault();
+  });
   document.addEventListener('touchstart', (e) => {
-    // Only prevent default if it's not a multi-touch gesture intended for zoom,
-    // although touch-action: none should handle that.
-    e.preventDefault();
+    if (!shouldAllowTouch(e)) {
+      e.preventDefault();
+    }
   }, { passive: false });
-  document.addEventListener('pointerdown', (e) => e.preventDefault(), { passive: false });
+  document.addEventListener('pointerdown', (e) => {
+    if (!shouldAllowTouch(e)) e.preventDefault();
+  }, { passive: false });
   
   function applyStyles() {
     const virtualGamepadLeft = document.querySelector('.ejs_virtualGamepad_left');


### PR DESCRIPTION
- Added a `shouldAllowTouch()` function in `gamepad.js` to inspect `e.target` for touch and pointer events.
- Elements within `#book-container`, `#custom-modal-overlay`, `#ui-layer`, and `.ejs_menu_parent` are now exempt from the global `e.preventDefault()` calls, allowing them to remain interactive.
- Removed the redundant and unconditional `contextmenu` listener in `app.js`.