### PR TITLE
Fix booklet animation trigger and gamepad drag handles

### DIFF
--- a/booklet/booklet.js
+++ b/booklet/booklet.js
@@ -145,7 +145,9 @@ bWrapper.addEventListener('animationend', () => {
     isButtonAnimating = false;
 });
 
-document.body.addEventListener('click', (e) => {
+// Use pointerdown instead of click, because mobile clicks are synthetic events based on touchstart/touchend
+// which are now blocked for the document body during gameplay.
+document.body.addEventListener('pointerdown', (e) => {
     // 1. Define elements that should be IGNORED (Clicking these should NOT open the manual)
     const isInteractiveElement =
         e.target.closest('.select_button') || // The Version/Start/Continue buttons

--- a/gamepad.js
+++ b/gamepad.js
@@ -98,8 +98,9 @@ window.initVirtualGamepad = function() {
     const isModal = e.target.closest('#custom-modal-overlay');
     const isUiLayer = e.target.closest('#ui-layer');
     const isEjsMenu = e.target.closest('.ejs_menu_parent') || e.target.closest('.ejs_menu_button');
+    const isGamepadDragHandle = e.target.closest('.ejs_virtualGamepad_left') || e.target.closest('.ejs_virtualGamepad_right');
 
-    return isBooklet || isModal || isUiLayer || isEjsMenu;
+    return isBooklet || isModal || isUiLayer || isEjsMenu || isGamepadDragHandle;
   }
 
   // Disable default actions globally, but allow them for our custom UI


### PR DESCRIPTION
- Replaced `click` event listener on `document.body` in `booklet.js` with `pointerdown` to bypass the synthetic click block caused by the global `touchstart` preventions.
- Added `.ejs_virtualGamepad_left` and `.ejs_virtualGamepad_right` drag handles to the `shouldAllowTouch()` exemption list in `gamepad.js` so they receive proper touch events.