### PR TITLE
Stop propagation on gamepad drag handles to prevent menu popup

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -147,6 +147,9 @@ window.initVirtualGamepad = function() {
     element.addEventListener('touchstart', (e) => {
       if (e.target !== element) return;
       
+      // Stop bubbling so EmulatorJS doesn't interpret this as a tap to open the menu
+      e.stopPropagation();
+
       clearTimeout(longPressTimer);
       longPressTimer = setTimeout(() => {
         isDragging = true;


### PR DESCRIPTION
- Added `e.stopPropagation()` in the `makeDraggable` `touchstart` listener inside `gamepad.js`. This prevents the touch event from bubbling up to EmulatorJS's main parent element, which mistakenly interprets the drag gesture as a tap to open the emulator menu bar.