### PR TITLE
Fix booklet animation not triggering on game canvas

### DIFF
--- a/booklet/booklet.js
+++ b/booklet/booklet.js
@@ -156,8 +156,7 @@ document.body.addEventListener('pointerdown', (e) => {
         e.target.closest('#button-wrapper') || // The Manual icon itself (let it handle its own click)
         e.target.closest('.ejs_context_menu') || // EmulatorJS specific menus
         e.target.closest('.ejs_menu_bar') || // EmulatorJS bars
-        e.target.closest('.ejs_virtualGamepad_parent') || // Gamepad controls and drag handles
-        e.target.closest('#game'); // The emulator game canvas
+        e.target.closest('.ejs_virtualGamepad_parent'); // Gamepad controls
 
     // 2. If we clicked any of those, do nothing.
     if (isInteractiveElement) {

--- a/styles/main.css
+++ b/styles/main.css
@@ -18,7 +18,6 @@ html {
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  touch-action: none;
 }
 
 .bg-layer { position: absolute; width: 100%; top: 50%; transform: translateY(-50%); max-width: 100vw; z-index: 0; opacity: 0.75; }
@@ -100,6 +99,7 @@ html {
 .modal-image { max-width: 100%; max-height: 400px; margin: 15px 0; border-radius: 4px; }
 
 /* Overrides for EmulatorJS virtual gamepad to eliminate mobile haptics */
+#game,
 .ejs_virtualGamepad_parent,
 .ejs_virtualGamepad_button {
   -webkit-touch-callout: none !important;


### PR DESCRIPTION
- Removed `#game` from the ignore list in the `booklet.js` `pointerdown` listener. Since `#game` takes up the entire background, ignoring it prevented the user from tapping the background to trigger the booklet animation while playing the game.