### PR TITLE
Fix toggle button visibility and state during forward navigation

### DIFF
--- a/version-manager.js
+++ b/version-manager.js
@@ -660,6 +660,8 @@ if (typeof window !== 'undefined') {
  * Handles the visual state of the booklet.
  * Returns TRUE if an action was performed (useful for stopping event chains).
  */
+let bookAnimationTimeout;
+
 function bookHandler(action) {
   const toggleButton = document.getElementById('toggleButton');
   const blurBackground = document.getElementById('blurBackground');
@@ -670,16 +672,27 @@ function bookHandler(action) {
   
   if (!toggleButton) return false;
   
+  // Clear any pending animation timeouts to prevent race conditions during rapid toggling
+  if (bookAnimationTimeout) {
+    clearTimeout(bookAnimationTimeout);
+    bookAnimationTimeout = null;
+  }
+
   if (action === 'open') {
     if (!toggleButton.checked) {
+      toggleButton.checked = true;
       restartButtonAnimation();
       
       if (blurBackground) blurBackground.style.display = 'block';
-      if (bWrapper) bWrapper.style.animationPlayState = 'paused';
+      if (bWrapper) {
+        // Delay pausing so it slides in first
+        bookAnimationTimeout = setTimeout(() => {
+          bWrapper.style.animationPlayState = 'paused';
+        }, 700);
+      }
       if (book) {
         book.style.left = '0';
         book.style.animation = 'rollIn 0.7s ease forwards';
-        toggleButton.checked = true;
       }
       if (s1) s1.play();
       return true; // Action performed


### PR DESCRIPTION
Fix toggle button visibility and state during forward navigation

Added `toggleButton.checked = true` to the `bookHandler`'s open state handling and wrapped the button wrapper pause styling in a `setTimeout` of 700ms to allow the slide-in animation to complete. Also addressed a race condition by tracking the timeout to prevent UI freezes on rapid toggle clicks.

---
*PR created automatically by Jules for task [12836456798369674345](https://jules.google.com/task/12836456798369674345) started by @not-that-james-coburn*