### PR TITLE
fix(ui): use css class to lock booklet button visibility on itch.io r…

### DIFF
--- a/booklet/booklet.css
+++ b/booklet/booklet.css
@@ -10,6 +10,11 @@
   animation: slide-in-wait-out 4s ease-in-out forwards 2s;
 }
 
+.button-locked-visible {
+  animation: none !important;
+  transform: translateX(90px) !important;
+}
+
 .toggle-button {
   display: none;
   /* Hides the checkbox */

--- a/booklet/booklet.js
+++ b/booklet/booklet.js
@@ -115,13 +115,14 @@ document.addEventListener('DOMContentLoaded', (event) => {
         if (toggleButton.checked) {
             window.history.pushState({ bookOpen: true }, '', '#booklet');
             blurBackground.style = `display: block; z-index: 30;`;
-            bWrapper.style.animationPlayState = 'paused';
+            bWrapper.classList.add('button-locked-visible');
             book.style.left = '0';
             book.style.animation = 'rollIn 0.7s ease forwards';
             document.getElementById("slide1").play();
             
         } else {
-            bWrapper.style.animationPlayState = 'running';
+            bWrapper.classList.remove('button-locked-visible');
+            restartButtonAnimation(); // restart the animation so it can slide out
             book.style.left = '-2200px';
             book.style.animation = 'rollOut 0.7s ease forwards';
             document.getElementById("slide2").play();
@@ -163,17 +164,9 @@ document.body.addEventListener('pointerdown', (e) => {
     if (isInteractiveElement) {
         return;
     }
-    const toggleButton = document.getElementById('toggleButton');
-    const isPaused = getComputedStyle(bWrapper).animationPlayState === 'paused';
-    if (!isButtonAnimating && !isPaused) {
+    const isLocked = bWrapper.classList.contains('button-locked-visible');
+    if (!isButtonAnimating && !isLocked) {
         isButtonAnimating = true;
         restartButtonAnimation();
-
-        // If the booklet is open, we need to pause the animation so the button stays on screen
-        if (toggleButton && toggleButton.checked) {
-            setTimeout(() => {
-                bWrapper.style.animationPlayState = 'paused';
-            }, 700);
-        }
     }
 });

--- a/version-manager.js
+++ b/version-manager.js
@@ -681,14 +681,10 @@ function bookHandler(action) {
   if (action === 'open') {
     if (!toggleButton.checked) {
       toggleButton.checked = true;
-      restartButtonAnimation();
       
       if (blurBackground) blurBackground.style.display = 'block';
       if (bWrapper) {
-        // Delay pausing so it slides in first
-        bookAnimationTimeout = setTimeout(() => {
-          bWrapper.style.animationPlayState = 'paused';
-        }, 700);
+        bWrapper.classList.add('button-locked-visible');
       }
       if (book) {
         book.style.left = '0';
@@ -697,14 +693,10 @@ function bookHandler(action) {
       if (s1) s1.play();
       return true; // Action performed
     } else {
-      // Edge case for resume on itch.io where button is checked but animation was lost
-      restartButtonAnimation();
+      // Itch.io resume fallback: if state is open, enforce the button class
       if (bWrapper) {
-        bookAnimationTimeout = setTimeout(() => {
-          bWrapper.style.animationPlayState = 'paused';
-        }, 700);
+        bWrapper.classList.add('button-locked-visible');
       }
-      return true;
     }
   }
   
@@ -712,7 +704,10 @@ function bookHandler(action) {
     if (toggleButton.checked) {
       toggleButton.checked = false;
       if (s2) s2.play();
-      if (bWrapper) bWrapper.style.animationPlayState = 'running';
+      if (bWrapper) {
+        bWrapper.classList.remove('button-locked-visible');
+        restartButtonAnimation(); // restart the animation so it can slide out
+      }
       if (book) {
         book.style.left = '-2200px';
         book.style.animation = 'rollOut 0.7s ease forwards';


### PR DESCRIPTION
…esume

Replaces the fragile timeout-based `animationPlayState: paused` approach with a robust CSS class (`.button-locked-visible`) that explicitly sets `transform` and disables `animation`. This guarantees the toggle button is fully visible whenever the booklet is open, and gracefully handles platform-specific edge cases (like itch.io browser state restoration) where JavaScript timeout animations fail to reliably re-trigger or sync.