### PR TITLE
Fix virtual gamepad scaling using device pixel density

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -48,10 +48,16 @@ window.initVirtualGamepad = function() {
                 touch-action: none; 
                 
                 /* scale up gamepad slightly */
-                transform: scale(1.16);
+                transform: scale(1);
                 /* Set origin so it scales upward and outward predictably */
                 transform-origin: bottom center;
-                
+            }
+
+            /* Apply scale ONLY to high-density displays (like Retina screens, modern phones/tablets) */
+            @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+                .ejs_virtualGamepad_left, .ejs_virtualGamepad_right {
+                    transform: scale(1.16);
+                }
             }
             .ejs_dpad_main {
               position: absolute;


### PR DESCRIPTION
This PR adjusts the virtual gamepad scaling logic to rely on the device's pixel density using CSS media queries. It restores a 1x base scale for standard displays while applying a 1.16x scale specifically for high-DPI displays to provide a more consistent physical size across different devices, resolving issues with it appearing inappropriately sized depending on screen resolution.

---
*PR created automatically by Jules for task [2967513272327192396](https://jules.google.com/task/2967513272327192396) started by @not-that-james-coburn*